### PR TITLE
엔티티에 인덱스 추가하기

### DIFF
--- a/src/main/java/com/practice/sns/domain/Comment.java
+++ b/src/main/java/com/practice/sns/domain/Comment.java
@@ -21,7 +21,9 @@ import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
-@Table(name = "\"comment\"")
+@Table(name = "\"comment\"", indexes = {
+        @Index(columnList = "post_id")
+})
 @NoArgsConstructor
 @SQLDelete(sql = "UPDATE \"comment\" SET deleted_at = NOW() where id=?")
 @Where(clause = "deleted_at is NULL")

--- a/src/main/java/com/practice/sns/domain/Like.java
+++ b/src/main/java/com/practice/sns/domain/Like.java
@@ -7,6 +7,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrePersist;
@@ -19,9 +20,11 @@ import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
-@Table(name = "\"like\"")
+@Table(name = "\"like\"", indexes = {
+        @Index(columnList = "post_id")
+})
 @NoArgsConstructor
-@SQLDelete(sql = "UPDATE \"post\" SET deleted_at = NOW() where id=?")
+@SQLDelete(sql = "UPDATE \"like\" SET deleted_at = NOW() where id=?")
 @Where(clause = "deleted_at is NULL")
 public class Like {
 

--- a/src/main/java/com/practice/sns/domain/Post.java
+++ b/src/main/java/com/practice/sns/domain/Post.java
@@ -8,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrePersist;
@@ -21,7 +22,9 @@ import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
-@Table(name = "\"post\"")
+@Table(name = "\"post\"", indexes = {
+        @Index(columnList = "user_id")
+})
 @NoArgsConstructor
 @SQLDelete(sql = "UPDATE \"post\" SET deleted_at = NOW() where id=?")
 @Where(clause = "deleted_at is NULL")

--- a/src/main/java/com/practice/sns/domain/User.java
+++ b/src/main/java/com/practice/sns/domain/User.java
@@ -11,6 +11,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
@@ -23,7 +24,9 @@ import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
-@Table(name = "\"user\"")
+@Table(name = "\"user\"", indexes = {
+        @Index(columnList = "user_name")
+})
 @NoArgsConstructor
 @SQLDelete(sql = "UPDATE \"user\" SET deleted_at = NOW() where id=?")
 @Where(clause = "deleted_at is NULL")


### PR DESCRIPTION
PK 이외의 키로 데이터를 조회할 때 속도를 빠르게 하기 위해 @Table 어노테이션의 `indexes =` 을 수정했다.

This closes #22