### PR TITLE
알림 기능 개발하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+// PostgreSQL에서 JsonB 타입 사용
+	implementation 'com.vladmihalcea:hibernate-types-52:2.17.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/practice/sns/controller/NotificationController.java
+++ b/src/main/java/com/practice/sns/controller/NotificationController.java
@@ -1,0 +1,26 @@
+package com.practice.sns.controller;
+
+import com.practice.sns.dto.response.NotificationResponseDto;
+import com.practice.sns.dto.response.Response;
+import com.practice.sns.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/notification")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping()
+    public Response<Page<NotificationResponseDto>> notificationList(Pageable pageable, Authentication authentication) {
+        return Response.success(
+                notificationService.getList(authentication.getName(), pageable).map(NotificationResponseDto::from));
+    }
+}

--- a/src/main/java/com/practice/sns/domain/Notification.java
+++ b/src/main/java/com/practice/sns/domain/Notification.java
@@ -1,0 +1,106 @@
+package com.practice.sns.domain;
+
+import com.practice.sns.domain.constant.NotificationType;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.Where;
+
+@Getter
+@Entity
+@Table(name = "\"notification\"", indexes = {
+        @Index(columnList = "user_id")
+})
+@NoArgsConstructor
+@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+@SQLDelete(sql = "UPDATE \"notification\" SET deleted_at = NOW() where id=?")
+@Where(clause = "deleted_at is NULL")
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @Type(type = "jsonb")
+    @Column(columnDefinition = "json")
+    private NotificationArgs notificationArgs;
+
+    @Column(name = "registered_at")
+    private Timestamp registeredAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    @Column(name = "deleted_at")
+    private Timestamp deletedAt;
+
+    @PrePersist
+    void registeredAt() {
+        this.registeredAt = Timestamp.from(Instant.now());
+    }
+
+    @PreUpdate
+    void updatedAt() {
+        this.updatedAt = Timestamp.from(Instant.now());
+    }
+
+    private Notification(Long id, User user, NotificationType notificationType, NotificationArgs notificationArgs) {
+        this.id = id;
+        this.user = user;
+        this.notificationType = notificationType;
+        this.notificationArgs = notificationArgs;
+    }
+
+    public static Notification of(User user, NotificationType notificationType, NotificationArgs notificationArgs) {
+        return new Notification(null, user, notificationType, notificationArgs);
+    }
+
+    public static Notification of(Long id, User user, NotificationType notificationType,
+                                  NotificationArgs notificationArgs) {
+        return new Notification(id, user, notificationType, notificationArgs);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Notification notification = (Notification) o;
+        return Objects.equals(id, notification.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}
+

--- a/src/main/java/com/practice/sns/domain/NotificationArgs.java
+++ b/src/main/java/com/practice/sns/domain/NotificationArgs.java
@@ -1,0 +1,14 @@
+package com.practice.sns.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class NotificationArgs {
+    // 알람을 발생시킨 사람
+    private Long fromUserId;
+    // 알람이 발생한 곳
+    private Long targetId;
+
+}

--- a/src/main/java/com/practice/sns/domain/constant/NotificationType.java
+++ b/src/main/java/com/practice/sns/domain/constant/NotificationType.java
@@ -1,0 +1,15 @@
+package com.practice.sns.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum NotificationType {
+
+    NEW_COMMENT_ON_POST("New comment!"),
+    NEW_LIKE_ON_POST("New Like!"),
+    ;
+
+    private final String message;
+}

--- a/src/main/java/com/practice/sns/dto/NotificationDto.java
+++ b/src/main/java/com/practice/sns/dto/NotificationDto.java
@@ -1,0 +1,33 @@
+package com.practice.sns.dto;
+
+import com.practice.sns.domain.Notification;
+import com.practice.sns.domain.NotificationArgs;
+import com.practice.sns.domain.constant.NotificationType;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationDto {
+
+    private Long id;
+    private UserDto user;
+    private NotificationType notificationType;
+    private NotificationArgs notificationArgs;
+    private Timestamp registeredAt;
+    private Timestamp updatedAt;
+    private Timestamp deletedAt;
+
+    public static NotificationDto from(Notification entity) {
+        return new NotificationDto(
+                entity.getId(),
+                UserDto.from(entity.getUser()),
+                entity.getNotificationType(),
+                entity.getNotificationArgs(),
+                entity.getRegisteredAt(),
+                entity.getUpdatedAt(),
+                entity.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/com/practice/sns/dto/response/NotificationResponseDto.java
+++ b/src/main/java/com/practice/sns/dto/response/NotificationResponseDto.java
@@ -1,0 +1,33 @@
+package com.practice.sns.dto.response;
+
+import com.practice.sns.domain.NotificationArgs;
+import com.practice.sns.domain.constant.NotificationType;
+import com.practice.sns.dto.NotificationDto;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationResponseDto {
+
+    private Long id;
+    private NotificationType notificationType;
+    private NotificationArgs notificationArgs;
+    private String text;
+    private Timestamp registeredAt;
+    private Timestamp updatedAt;
+    private Timestamp deletedAt;
+
+    public static NotificationResponseDto from(NotificationDto dto) {
+        return new NotificationResponseDto(
+                dto.getId(),
+                dto.getNotificationType(),
+                dto.getNotificationArgs(),
+                dto.getNotificationType().getMessage(),
+                dto.getRegisteredAt(),
+                dto.getUpdatedAt(),
+                dto.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/com/practice/sns/repository/NotificationRepository.java
+++ b/src/main/java/com/practice/sns/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package com.practice.sns.repository;
+
+import com.practice.sns.domain.Notification;
+import com.practice.sns.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    Page<Notification> findAllByUser(User user, Pageable pageable);
+}

--- a/src/main/java/com/practice/sns/service/CommentService.java
+++ b/src/main/java/com/practice/sns/service/CommentService.java
@@ -1,12 +1,16 @@
 package com.practice.sns.service;
 
 import com.practice.sns.domain.Comment;
+import com.practice.sns.domain.Notification;
+import com.practice.sns.domain.NotificationArgs;
 import com.practice.sns.domain.Post;
 import com.practice.sns.domain.User;
+import com.practice.sns.domain.constant.NotificationType;
 import com.practice.sns.dto.CommentDto;
 import com.practice.sns.exception.ErrorCode;
 import com.practice.sns.exception.SnsApplicationException;
 import com.practice.sns.repository.CommentRepository;
+import com.practice.sns.repository.NotificationRepository;
 import com.practice.sns.repository.PostRepository;
 import com.practice.sns.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,8 +25,8 @@ public class CommentService {
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
-
     private final CommentRepository commentRepository;
+    private final NotificationRepository notificationRepository;
 
     @Transactional
     public void comment(String userName, Long postId, String body) {
@@ -38,6 +42,12 @@ public class CommentService {
 
         //댓글을 저장한다
         commentRepository.save(Comment.of(body, user, post));
+
+        // 알람을 발생시킨다
+        notificationRepository.save(
+                Notification.of(post.getUser(), NotificationType.NEW_COMMENT_ON_POST,
+                        new NotificationArgs(user.getId(), post.getId())));
+
     }
 
     @Transactional

--- a/src/main/java/com/practice/sns/service/LikeService.java
+++ b/src/main/java/com/practice/sns/service/LikeService.java
@@ -1,11 +1,15 @@
 package com.practice.sns.service;
 
 import com.practice.sns.domain.Like;
+import com.practice.sns.domain.Notification;
+import com.practice.sns.domain.NotificationArgs;
 import com.practice.sns.domain.Post;
 import com.practice.sns.domain.User;
+import com.practice.sns.domain.constant.NotificationType;
 import com.practice.sns.exception.ErrorCode;
 import com.practice.sns.exception.SnsApplicationException;
 import com.practice.sns.repository.LikeRepository;
+import com.practice.sns.repository.NotificationRepository;
 import com.practice.sns.repository.PostRepository;
 import com.practice.sns.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +22,8 @@ public class LikeService {
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
-
     private final LikeRepository likeRepository;
+    private final NotificationRepository notificationRepository;
 
     @Transactional
     public void like(String userName, Long postId) {
@@ -42,6 +46,12 @@ public class LikeService {
 
         // 좋아요를 저장한다
         likeRepository.save(Like.of(user, post));
+
+        // 알림을 발생시킨다
+        notificationRepository.save(
+                Notification.of(post.getUser(), NotificationType.NEW_LIKE_ON_POST,
+                        new NotificationArgs(user.getId(), post.getId())));
+
     }
 
     public int countLike(Long postId) {

--- a/src/main/java/com/practice/sns/service/NotificationService.java
+++ b/src/main/java/com/practice/sns/service/NotificationService.java
@@ -1,0 +1,31 @@
+package com.practice.sns.service;
+
+import com.practice.sns.domain.Notification;
+import com.practice.sns.domain.User;
+import com.practice.sns.dto.NotificationDto;
+import com.practice.sns.exception.ErrorCode;
+import com.practice.sns.exception.SnsApplicationException;
+import com.practice.sns.repository.NotificationRepository;
+import com.practice.sns.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final UserRepository userRepository;
+    private final NotificationRepository notificationRepository;
+
+    public Page<NotificationDto> getList(String userName, Pageable pageable) {
+        // 유저를 찾는다
+        User user = userRepository.findByUserName(userName)
+                .orElseThrow(() -> new SnsApplicationException(ErrorCode.USER_NOT_FOUND,
+                        String.format("User Name %s does not exist", userName)));
+        System.out.println(user.getId());
+
+        return notificationRepository.findAllByUser(user, pageable).map(NotificationDto::from);
+    }
+}

--- a/src/main/java/com/practice/sns/service/PostService.java
+++ b/src/main/java/com/practice/sns/service/PostService.java
@@ -27,6 +27,7 @@ public class PostService {
 
         // 포스트를 저장한다
         postRepository.save(Post.of(title, body, user));
+
     }
 
     @Transactional
@@ -38,12 +39,14 @@ public class PostService {
                         String.format("User Name %s does not exist", userName)));
 
         // 포스트를 찾는다
-        Post post = postRepository.findById(postId).orElseThrow(() -> new SnsApplicationException(ErrorCode.POST_NOT_FOUND,
-                String.format("Post ID %d does not exist", postId)));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new SnsApplicationException(ErrorCode.POST_NOT_FOUND,
+                        String.format("Post ID %d does not exist", postId)));
 
         // 포스트 작성자를 확인한다
         if (!post.getUser().equals(user)) {
-            throw new SnsApplicationException(ErrorCode.INVALID_PERMISSION, String.format("User Name %s has no permission to modify Post ID %d", userName, postId));
+            throw new SnsApplicationException(ErrorCode.INVALID_PERMISSION,
+                    String.format("User Name %s has no permission to modify Post ID %d", userName, postId));
         }
 
         // 포스트를 저장한다
@@ -61,12 +64,14 @@ public class PostService {
                         String.format("User Name %s does not exist", userName)));
 
         // 포스트를 찾는다
-        Post post = postRepository.findById(postId).orElseThrow(() -> new SnsApplicationException(ErrorCode.POST_NOT_FOUND,
-                String.format("Post ID %d does not exist", postId)));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new SnsApplicationException(ErrorCode.POST_NOT_FOUND,
+                        String.format("Post ID %d does not exist", postId)));
 
         // 포스트 작성자를 확인한다
         if (!post.getUser().equals(user)) {
-            throw new SnsApplicationException(ErrorCode.INVALID_PERMISSION, String.format("User Name %s has no permission to modify Post ID %d", userName, postId));
+            throw new SnsApplicationException(ErrorCode.INVALID_PERMISSION,
+                    String.format("User Name %s has no permission to modify Post ID %d", userName, postId));
         }
 
         postRepository.delete(post);

--- a/src/test/java/com/practice/sns/controller/NotificationControllerTest.java
+++ b/src/test/java/com/practice/sns/controller/NotificationControllerTest.java
@@ -1,0 +1,57 @@
+package com.practice.sns.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.practice.sns.exception.ErrorCode;
+import com.practice.sns.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    NotificationService notificationService;
+
+    @Test
+    @WithMockUser
+    void 알림기능이_정상적으로_동작한다() throws Exception {
+        // Given
+        when(notificationService.getList(any(), any())).thenReturn(Page.empty());
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/users/notification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void 알림리스트_요청시_로그인하지_않은경우_에러반환() throws Exception {
+        // Given
+        when(notificationService.getList(any(), any())).thenReturn(Page.empty());
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/users/notification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().is(ErrorCode.INVALID_PERMISSION.getStatus().value()));
+    }
+}

--- a/src/test/java/com/practice/sns/service/NotificationServiceTest.java
+++ b/src/test/java/com/practice/sns/service/NotificationServiceTest.java
@@ -1,0 +1,64 @@
+package com.practice.sns.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.practice.sns.domain.Like;
+import com.practice.sns.domain.Post;
+import com.practice.sns.domain.User;
+import com.practice.sns.exception.ErrorCode;
+import com.practice.sns.exception.SnsApplicationException;
+import com.practice.sns.fixture.TestInfoFixture;
+import com.practice.sns.repository.LikeRepository;
+import com.practice.sns.repository.NotificationRepository;
+import com.practice.sns.repository.PostRepository;
+import com.practice.sns.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@SpringBootTest
+public class NotificationServiceTest {
+
+    @Autowired
+    private NotificationService notificationService;
+    @MockBean
+    private NotificationRepository notificationRepository;
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    void 알림목록_요청이_성공한_경우() {
+        // Given
+        Pageable pageable = mock(Pageable.class);
+        TestInfoFixture.TestInfo fixture = TestInfoFixture.get();
+        User user = User.of(fixture.getUserId(), fixture.getUserName(), fixture.getPassword());
+        when(userRepository.findByUserName(fixture.getUserName())).thenReturn(Optional.of(user));
+        when(notificationRepository.findAllByUser(eq(user), any())).thenReturn(Page.empty());
+
+        // When & Then
+        assertDoesNotThrow(() -> notificationService.getList(fixture.getUserName(), pageable));
+    }
+
+    @Test
+    void 알림목록_요청시_요청한_유저가_존재하지_않는_경우() {
+        // Given
+        Pageable pageable = mock(Pageable.class);
+        TestInfoFixture.TestInfo fixture = TestInfoFixture.get();
+        when(userRepository.findByUserName(fixture.getUserName())).thenReturn(Optional.empty());
+
+        // When & Then
+        SnsApplicationException exception = assertThrows(SnsApplicationException.class, () ->
+                notificationService.getList(fixture.getUserName(), pageable));
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
[알림 기능 시퀀스 다이어그램](https://github.com/TaemHam/SNS-Clone-Coding/issues/24#issuecomment-1383294830)에 맞춰 댓글 기능에 대한 테스트 코드를 작성하고, 기능을 구현했다.

추후 확장을 고려해, 알림 메시지 작성시 필요한 정보를 유연하게 저장할 용도로 jsonb 데이터 유형을 선택했고, 그를 위해 추가적으로 `com.vladmihalcea:hibernate-types-52:2.17.3` 의존성을 추가했다.

* [스프링부트 PostgreSQL로 jsonb 타입 설정하기](https://www.oofbird.me/66)

This closes #24 