### PR TITLE
DB 관련 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.mockito:mockito-inline:3.6.0'
 
 // JWT 관련 의존성
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/practice/sns/controller/NotificationController.java
+++ b/src/main/java/com/practice/sns/controller/NotificationController.java
@@ -1,8 +1,12 @@
 package com.practice.sns.controller;
 
+import com.practice.sns.dto.UserDto;
 import com.practice.sns.dto.response.NotificationResponseDto;
 import com.practice.sns.dto.response.Response;
+import com.practice.sns.exception.ErrorCode;
+import com.practice.sns.exception.SnsApplicationException;
 import com.practice.sns.service.NotificationService;
+import com.practice.sns.util.ClassUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,7 +24,12 @@ public class NotificationController {
 
     @GetMapping()
     public Response<Page<NotificationResponseDto>> notificationList(Pageable pageable, Authentication authentication) {
+        // DTO로 업캐스팅
+        UserDto userDto = ClassUtils.getCastInstance(authentication.getPrincipal(), UserDto.class)
+                .orElseThrow(() -> new SnsApplicationException(ErrorCode.INTERNAL_SERVER_ERROR,
+                        "Casting to UserDto class failed"));
+
         return Response.success(
-                notificationService.getList(authentication.getName(), pageable).map(NotificationResponseDto::from));
+                notificationService.getList(userDto.getId(), pageable).map(NotificationResponseDto::from));
     }
 }

--- a/src/main/java/com/practice/sns/domain/Notification.java
+++ b/src/main/java/com/practice/sns/domain/Notification.java
@@ -9,6 +9,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -40,7 +41,7 @@ public class Notification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/practice/sns/dto/NotificationDto.java
+++ b/src/main/java/com/practice/sns/dto/NotificationDto.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 public class NotificationDto {
 
     private Long id;
-    private UserDto user;
     private NotificationType notificationType;
     private NotificationArgs notificationArgs;
     private Timestamp registeredAt;
@@ -22,7 +21,6 @@ public class NotificationDto {
     public static NotificationDto from(Notification entity) {
         return new NotificationDto(
                 entity.getId(),
-                UserDto.from(entity.getUser()),
                 entity.getNotificationType(),
                 entity.getNotificationArgs(),
                 entity.getRegisteredAt(),

--- a/src/main/java/com/practice/sns/repository/NotificationRepository.java
+++ b/src/main/java/com/practice/sns/repository/NotificationRepository.java
@@ -1,7 +1,6 @@
 package com.practice.sns.repository;
 
 import com.practice.sns.domain.Notification;
-import com.practice.sns.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    Page<Notification> findAllByUser(User user, Pageable pageable);
+    Page<Notification> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/practice/sns/service/NotificationService.java
+++ b/src/main/java/com/practice/sns/service/NotificationService.java
@@ -1,12 +1,7 @@
 package com.practice.sns.service;
 
-import com.practice.sns.domain.Notification;
-import com.practice.sns.domain.User;
 import com.practice.sns.dto.NotificationDto;
-import com.practice.sns.exception.ErrorCode;
-import com.practice.sns.exception.SnsApplicationException;
 import com.practice.sns.repository.NotificationRepository;
-import com.practice.sns.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,17 +10,9 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
-
-    private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
 
-    public Page<NotificationDto> getList(String userName, Pageable pageable) {
-        // 유저를 찾는다
-        User user = userRepository.findByUserName(userName)
-                .orElseThrow(() -> new SnsApplicationException(ErrorCode.USER_NOT_FOUND,
-                        String.format("User Name %s does not exist", userName)));
-        System.out.println(user.getId());
-
-        return notificationRepository.findAllByUser(user, pageable).map(NotificationDto::from);
+    public Page<NotificationDto> getList(Long userId, Pageable pageable) {
+        return notificationRepository.findAllByUserId(userId, pageable).map(NotificationDto::from);
     }
 }

--- a/src/main/java/com/practice/sns/util/ClassUtils.java
+++ b/src/main/java/com/practice/sns/util/ClassUtils.java
@@ -1,0 +1,10 @@
+package com.practice.sns.util;
+
+import java.util.Optional;
+
+public class ClassUtils {
+
+    public static <T> Optional<T> getCastInstance(Object obj, Class<T> cls) {
+        return cls != null && cls.isInstance(obj) ? Optional.of(cls.cast(obj)) : Optional.empty();
+    }
+}

--- a/src/test/java/com/practice/sns/service/FeedServiceTest.java
+++ b/src/test/java/com/practice/sns/service/FeedServiceTest.java
@@ -8,12 +8,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.practice.sns.domain.Post;
 import com.practice.sns.domain.User;
 import com.practice.sns.exception.ErrorCode;
 import com.practice.sns.exception.SnsApplicationException;
 import com.practice.sns.fixture.TestInfoFixture;
-import com.practice.sns.fixture.UserEntityFixture;
 import com.practice.sns.repository.PostRepository;
 import com.practice.sns.repository.UserRepository;
 import java.util.Optional;
@@ -67,7 +65,7 @@ public class FeedServiceTest {
 
         // When & Then
         SnsApplicationException e = assertThrows(SnsApplicationException.class,
-                () -> feedService.list(pageable));
+                () -> feedService.my(pageable, fixture.getUserName()));
         assertEquals(ErrorCode.USER_NOT_FOUND, e.getErrorCode());
     }
 }

--- a/src/test/java/com/practice/sns/service/NotificationServiceTest.java
+++ b/src/test/java/com/practice/sns/service/NotificationServiceTest.java
@@ -1,24 +1,13 @@
 package com.practice.sns.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.practice.sns.domain.Like;
-import com.practice.sns.domain.Post;
 import com.practice.sns.domain.User;
-import com.practice.sns.exception.ErrorCode;
-import com.practice.sns.exception.SnsApplicationException;
 import com.practice.sns.fixture.TestInfoFixture;
-import com.practice.sns.repository.LikeRepository;
 import com.practice.sns.repository.NotificationRepository;
-import com.practice.sns.repository.PostRepository;
-import com.practice.sns.repository.UserRepository;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,8 +22,6 @@ public class NotificationServiceTest {
     private NotificationService notificationService;
     @MockBean
     private NotificationRepository notificationRepository;
-    @MockBean
-    private UserRepository userRepository;
 
     @Test
     void 알림목록_요청이_성공한_경우() {
@@ -42,23 +29,9 @@ public class NotificationServiceTest {
         Pageable pageable = mock(Pageable.class);
         TestInfoFixture.TestInfo fixture = TestInfoFixture.get();
         User user = User.of(fixture.getUserId(), fixture.getUserName(), fixture.getPassword());
-        when(userRepository.findByUserName(fixture.getUserName())).thenReturn(Optional.of(user));
-        when(notificationRepository.findAllByUser(eq(user), any())).thenReturn(Page.empty());
+        when(notificationRepository.findAllByUserId(any(), any())).thenReturn(Page.empty());
 
         // When & Then
-        assertDoesNotThrow(() -> notificationService.getList(fixture.getUserName(), pageable));
-    }
-
-    @Test
-    void 알림목록_요청시_요청한_유저가_존재하지_않는_경우() {
-        // Given
-        Pageable pageable = mock(Pageable.class);
-        TestInfoFixture.TestInfo fixture = TestInfoFixture.get();
-        when(userRepository.findByUserName(fixture.getUserName())).thenReturn(Optional.empty());
-
-        // When & Then
-        SnsApplicationException exception = assertThrows(SnsApplicationException.class, () ->
-                notificationService.getList(fixture.getUserName(), pageable));
-        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        assertDoesNotThrow(() -> notificationService.getList(fixture.getUserId(), pageable));
     }
 }


### PR DESCRIPTION
유저 정보 조회가 필터와 서비스 레이어, 두 계층에서 일어나는 것을, 한 번으로 줄였다.
알림 기능의 N+1 문제를 해결하기 위해, FetchType 을 Lazy로, `application.yaml`에 `default_batch_fetch_size` 설정을 추가했다.

This closes #27 