### PR TITLE
포스트 삭제시 댓글과 좋아요 삭제되도록 구현

### DIFF
--- a/src/main/java/com/practice/sns/controller/LikeController.java
+++ b/src/main/java/com/practice/sns/controller/LikeController.java
@@ -24,7 +24,7 @@ public class LikeController {
     }
 
     @GetMapping()
-    public Response<Integer> countLike(@PathVariable Long postId) {
+    public Response<Long> countLike(@PathVariable Long postId) {
         return Response.success(likeService.countLike(postId));
     }
 }

--- a/src/main/java/com/practice/sns/repository/CommentRepository.java
+++ b/src/main/java/com/practice/sns/repository/CommentRepository.java
@@ -5,10 +5,19 @@ import com.practice.sns.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findAllByPost(Post post, Pageable pageable);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Comment entity SET deleted_at = NOW() WHERE entity.post = :post")
+    void deleteAllByPost(@Param("post") Post post);
 }

--- a/src/main/java/com/practice/sns/repository/LikeRepository.java
+++ b/src/main/java/com/practice/sns/repository/LikeRepository.java
@@ -5,12 +5,21 @@ import com.practice.sns.domain.Post;
 import com.practice.sns.domain.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     Optional<Like> findByUserAndPost(User user, Post post);
 
-    int countAllByPost(Post post);
+    long countAllByPost(Post post);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Like entity SET deleted_at = NOW() where entity.post = :post")
+    void deleteAllByPost(@Param("post") Post post);
 }

--- a/src/main/java/com/practice/sns/service/LikeService.java
+++ b/src/main/java/com/practice/sns/service/LikeService.java
@@ -54,7 +54,7 @@ public class LikeService {
 
     }
 
-    public int countLike(Long postId) {
+    public long countLike(Long postId) {
 
         // 포스트를 찾는다
         Post post = postRepository.findById(postId)

--- a/src/main/java/com/practice/sns/service/PostService.java
+++ b/src/main/java/com/practice/sns/service/PostService.java
@@ -5,6 +5,8 @@ import com.practice.sns.domain.User;
 import com.practice.sns.dto.PostDto;
 import com.practice.sns.exception.ErrorCode;
 import com.practice.sns.exception.SnsApplicationException;
+import com.practice.sns.repository.CommentRepository;
+import com.practice.sns.repository.LikeRepository;
 import com.practice.sns.repository.PostRepository;
 import com.practice.sns.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -75,5 +79,8 @@ public class PostService {
         }
 
         postRepository.delete(post);
+        commentRepository.deleteAllByPost(post);
+        likeRepository.deleteAllByPost(post);
+
     }
 }


### PR DESCRIPTION
포스트와 댓글, 포스트와 좋아요 모두 단방향으로 매핑되어 있기 때문에, 영속성 전이를 사용하지 않고 각각의 Repository를 호출해 삭제하도록 구현했다.

This closes #30