### PR TITLE
캐싱을 통해 DB 호출 수 줄이기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 
 // PostgreSQL에서 JsonB 타입 사용
 	implementation 'com.vladmihalcea:hibernate-types-52:2.17.3'
+
+// Redis 사용
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/practice/sns/config/AuthenticationConfig.java
+++ b/src/main/java/com/practice/sns/config/AuthenticationConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -22,10 +23,15 @@ public class AuthenticationConfig extends WebSecurityConfigurerAdapter {
     private String secretKey;
 
     @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().regexMatchers("^(?!/api/).*")
+                .antMatchers("/api/*/users/join", "/api/*/users/login");
+    }
+
+    @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable() // RestAPI를 이용한 서버는 서버에 인증정보를 저장하지 않기 때문에 csrf 코드들을 작성할 필요가 없다.
                 .authorizeRequests()
-                .antMatchers("/api/*/users/join", "/api/*/users/login").permitAll()
                 .antMatchers("/api/**").authenticated()
                 .and()
                 .sessionManagement()

--- a/src/main/java/com/practice/sns/config/RedisConfig.java
+++ b/src/main/java/com/practice/sns/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.practice.sns.config;
+
+
+import com.practice.sns.dto.UserDto;
+import io.lettuce.core.RedisURI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisURI redisURI = RedisURI.create(redisProperties.getUrl());
+        org.springframework.data.redis.connection.RedisConfiguration configuration = LettuceConnectionFactory.createRedisConfiguration(
+                redisURI);
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(configuration);
+        factory.afterPropertiesSet();
+        return factory;
+    }
+
+    @Bean
+    public RedisTemplate<String, UserDto> userRedisTemplate() {
+        RedisTemplate<String, UserDto> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<UserDto>(UserDto.class));
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/practice/sns/dto/UserDto.java
+++ b/src/main/java/com/practice/sns/dto/UserDto.java
@@ -1,5 +1,7 @@
 package com.practice.sns.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.practice.sns.domain.User;
 import com.practice.sns.domain.constant.UserRole;
 import java.sql.Timestamp;
@@ -7,16 +9,19 @@ import java.util.Collection;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserDto implements UserDetails {
 
     private Long id;
-    private String userName;
+    private String username;
     private String password;
     private UserRole userRole;
     private Timestamp registeredAt;
@@ -36,31 +41,31 @@ public class UserDto implements UserDetails {
     }
 
     @Override
+    @JsonIgnore
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(userRole.toString()));
     }
 
     @Override
-    public String getUsername() {
-        return userName;
-    }
-
-    @Override
+    @JsonIgnore
     public boolean isAccountNonExpired() {
         return deletedAt == null;
     }
 
     @Override
+    @JsonIgnore
     public boolean isAccountNonLocked() {
         return deletedAt == null;
     }
 
     @Override
+    @JsonIgnore
     public boolean isCredentialsNonExpired() {
         return deletedAt == null;
     }
 
     @Override
+    @JsonIgnore
     public boolean isEnabled() {
         return deletedAt == null;
     }

--- a/src/main/java/com/practice/sns/repository/UserCacheRepository.java
+++ b/src/main/java/com/practice/sns/repository/UserCacheRepository.java
@@ -1,0 +1,36 @@
+package com.practice.sns.repository;
+
+
+import com.practice.sns.dto.UserDto;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class UserCacheRepository {
+
+    private final RedisTemplate<String, UserDto> userRedisTemplate;
+    private final static Duration USER_CACHE_TTL = Duration.ofDays(3);
+
+    public void setUser(UserDto user) {
+        String key = getKey(user.getUsername());
+        log.info("Set User to Redis {}, {}", key, user);
+        userRedisTemplate.opsForValue().set(key, user, USER_CACHE_TTL);
+    }
+
+    public Optional<UserDto> getUser(String username) {
+        String key = getKey(username);
+        UserDto user = userRedisTemplate.opsForValue().get(key);
+        log.info("Get User to Redis {}, {}", key, user);
+        return Optional.ofNullable(user);
+    }
+
+    public String getKey(String username) {
+        return "USER:" + username;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,9 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
 
+  redis:
+    url: redis://svc.gksl2.cloudtype.app:32434
+
 jwt:
   secret-key: sns-clone-coding-project.secret_key
   # TODO: Refresh Token 구현

--- a/src/test/java/com/practice/sns/service/UserServiceTest.java
+++ b/src/test/java/com/practice/sns/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import com.practice.sns.domain.User;
 import com.practice.sns.exception.ErrorCode;
 import com.practice.sns.exception.SnsApplicationException;
 import com.practice.sns.fixture.UserEntityFixture;
+import com.practice.sns.repository.UserCacheRepository;
 import com.practice.sns.repository.UserRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,10 @@ public class UserServiceTest {
 
     @MockBean
     private UserRepository userRepository;
+
+    @MockBean
+    private UserCacheRepository userCacheRepository;
+
 
     @MockBean
     private BCryptPasswordEncoder encoder;


### PR DESCRIPTION
Redis를 캐시 서버로 설정해 대규모 트래픽 발생시 DB의 부하를 줄여보도록 했다.

캐싱할 데이터는 일단 유저 정보로 결정했고, 로그인 시에 캐싱할 정보를 불러오도록 했다.

This closes #29